### PR TITLE
Fixed error on PHP 7.0 when accessing json decoded members

### DIFF
--- a/lib/Session.php
+++ b/lib/Session.php
@@ -42,6 +42,7 @@ class Session extends Resource {
     if ($jwt['m']) {
       $mbs = $user['memberships'] = [];
       foreach ($jwt['m'] as $m) {
+        $m = (array)$m;
         foreach (['cs', 'o', 'oid', 'ocs', 'p'] as $attr) {
           if (!isset($m[$attr]))
             $m[$attr] = null;


### PR DESCRIPTION
Fixed error: "Cannot use object of type stdClass as array" on PHP 7.0

This error occurs if extended JWT information is enabled inside AuthRocket settings (via management website).